### PR TITLE
Fixed ability to use HTTP in and out nodes.

### DIFF
--- a/lib/oracledb.js
+++ b/lib/oracledb.js
@@ -85,7 +85,7 @@ module.exports = function (RED) {
             }
             var resultAction = msg.resultAction || node.resultAction;
             var resultSetLimit = parseInt(msg.resultSetLimit || node.resultLimit, 10);
-            node.server.query(node, query, values, resultAction, resultSetLimit);
+            node.server.query(node, query, values, resultAction, resultSetLimit, msg);
         });
         //};
         initialize(node);
@@ -167,7 +167,8 @@ module.exports = function (RED) {
                 });
             }
         };
-        node.query = function (requestingNode, query, values, resultAction, resultSetLimit) {
+        node.query = function (requestingNode, query, values, resultAction, resultSetLimit, msg) {
+            
             // console.log("requestingNode: " + requestingNode);
             // console.log("query: " + query);
             // console.log("values: " + values);
@@ -184,6 +185,7 @@ module.exports = function (RED) {
                     resultSet: resultAction === "multi"
                 };
                 node.connection.execute(query, values, options, function (err, result) {
+                    //console.log(msg);
                     if (err) {
                         requestingNode.error("Oracle query error: " + err.message);
                         var errorCode = err.message.slice(0, 9);
@@ -193,20 +195,19 @@ module.exports = function (RED) {
                             node.connection = null;
                             if (node.reconnect) {
                                 node.log("Oracle server connection lost, retry in " + node.reconnectTimeout + " ms");
-                                node.reconnecting = setTimeout(node.query, node.reconnectTimeout, requestingNode, query, values, resultAction, resultSetLimit);
+                                node.reconnecting = setTimeout(node.query, node.reconnectTimeout, requestingNode, query, values, resultAction, resultSetLimit, msg);
                             }
                         }
                     }
                     else {
                         switch (resultAction) {
                             case "single":
-                                requestingNode.send({
-                                    payload: result.rows
-                                });
+                                msg.payload = result.rows;
+                                requestingNode.send(msg);
                                 requestingNode.log("Oracle query single result rows sent");
                                 break;
                             case "multi":
-                                node.fetchRowsFromResultSet(requestingNode, result.resultSet, resultSetLimit);
+                                node.fetchRowsFromResultSet(requestingNode, result.resultSet, resultSetLimit, msg);
                                 requestingNode.log("Oracle query multi result rows sent");
                                 break;
                             default:
@@ -223,12 +224,13 @@ module.exports = function (RED) {
                     query: query,
                     values: values,
                     resultAction: resultAction,
-                    resultSetLimit: resultSetLimit
+                    resultSetLimit: resultSetLimit,
+                    msg: msg
                 });
                 node.claimConnection();
             }
         };
-        node.fetchRowsFromResultSet = function (requestingNode, resultSet, maxRows) {
+        node.fetchRowsFromResultSet = function (requestingNode, resultSet, maxRows, msg) {
             resultSet.getRows(maxRows, function (err, rows) {
                 if (err) {
                     requestingNode.error("Oracle resultSet error: " + err.message);
@@ -241,18 +243,17 @@ module.exports = function (RED) {
                     });
                 }
                 else {
-                    requestingNode.send({
-                        payload: rows
-                    });
+                    msg.payload = rows;
+                    requestingNode.send(msg);
                     requestingNode.log("Oracle query resultSet rows sent");
-                    node.fetchRowsFromResultSet(requestingNode, resultSet, maxRows);
+                    node.fetchRowsFromResultSet(requestingNode, resultSet, maxRows, msg);
                 }
             });
         };
         node.queryQueued = function () {
             while (node.connection && node.queryQueue.length > 0) {
                 var e = node.queryQueue.shift();
-                node.query(e.requestingNode, e.query, e.values, e.resultAction, e.resultSetLimit, e.sendResult);
+                node.query(e.requestingNode, e.query, e.values, e.resultAction, e.resultSetLimit, e.msg);
             }
         };
     }


### PR DESCRIPTION
Module was not passing through properties on the msg object (besides payload) which prevented HTTP input (req and res) properties from being passed to HTTP output. This fix allows the received "msg" object to be passed through and adds the query output to the msg.payload property.